### PR TITLE
Veracode SCA: fixes for vulnerable libraries

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -19,7 +19,7 @@
 	<properties>
 		<spring.version>4.3.10.RELEASE</spring.version>
 		<springboot.version>2.3.1.RELEASE</springboot.version>
-		<fileupload.version>1.3.2</fileupload.version>
+		<fileupload.version>1.3.3</fileupload.version>
 	</properties>
 
 	<!-- Dependencies begin here -->
@@ -102,19 +102,19 @@
 		<dependency>
 			<groupId>org.mindrot</groupId>
 			<artifactId>jbcrypt</artifactId>
-			<version>0.3m</version>
+			<version>0.4</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.keycloak</groupId>
 			<artifactId>keycloak-saml-core</artifactId>
-			<version>1.8.1.Final</version>
+			<version>2.5.5.Final</version>
 		</dependency>
 
 		<dependency>
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
-			<version>5.1.48</version>
+			<version>8.0.16</version>
 		</dependency>
 
 		<dependency>
@@ -130,7 +130,7 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-collections4</artifactId>
-			<version>4.0</version>
+			<version>4.1</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
This pull request was generated by Veracode SCA to upgrade the following vulnerable libraries:

| Type | Library | From | To | Breaking |
| --- | --- | --- | --- | --- |
| MAVEN | `commons-fileupload:commons-fileupload` | 1.3.2 | 1.3.3 | No |
| MAVEN | `mysql:mysql-connector-java` | 5.1.48 | 8.0.16 | No |
| MAVEN | `org.keycloak:keycloak-saml-core` | 1.8.1.Final | 2.5.5.Final | No |
| MAVEN | `org.apache.commons:commons-collections4` | 4.0 | 4.1 | No |
| MAVEN | `org.mindrot:jbcrypt` | 0.3m | 0.4 | No |

Note that we only upgrade libraries which have versions without any known vulnerabilities. For more information, please see the corresponding [Veracode SCA report](https://sca.analysiscenter.veracode.com/teams/RjjC7dn/scans/31252265).

The **Breaking** column states the likelihood that updating to the recommended library version will cause breaking changes in your code. Please verify that the changes here won't cause issues with your project before merging.

To learn more about this feature, please visit our [Help Center](https://help.veracode.com/r/About_Automatic_Pull_Requests) for documentation.

Note: this pull request was generated because you or someone else with access to this repository granted Veracode SCA access to submit pull requests.
<!-- srcclr-pr-id-079314768aadd6c266d83f4042bb65fcdaeb16ccd64d2fe03d6a699ee26445b0 -->
